### PR TITLE
キャッシュ別削除APIでのタイムアウトエラー対応

### DIFF
--- a/wp-sacloud-webaccel.php
+++ b/wp-sacloud-webaccel.php
@@ -1629,6 +1629,7 @@ class SacloudClient
     {
         $args = $this->getRequestArgs();
         $args['body'] = json_encode($data);
+        $args['timeout'] = 60;
 
         $response = wp_remote_post($url, $args);
         if (is_wp_error($response)) {


### PR DESCRIPTION
cURLでPOSTする際のタイムアウトをデフォルト(5秒) -> 60秒に延長

参考: wp_remote_post() -> https://developer.wordpress.org/reference/functions/wp_remote_post/#parameters