### PR TITLE
Switch API key validation to use GET /site and update default zone to is1a

### DIFF
--- a/wp-sacloud-webaccel.php
+++ b/wp-sacloud-webaccel.php
@@ -149,7 +149,7 @@ function sacloud_webaccel_validate_options($values)
     $default_values = array(
         'api-key' => '',
         'api-secret' => '',
-        'api-zone' => 'tk1a',
+        'api-zone' => 'is1a',
         'use-subdomain' => 0,
         'subdomain-name' => '',
         'subdomain-ssl' => 0,
@@ -1498,7 +1498,6 @@ class SacloudClient
 
     const API_BASE_URL_FORAMT = 'https://secure.sakura.ad.jp/cloud/zone/%s/api/%s';
 
-    const API_CLOUD_SUFFIX = "cloud/1.1/";
     const API_WEBACCEL_SUFFIX = "webaccel/1.0/";
 
     function __construct($key, $secret, $zone)
@@ -1519,8 +1518,6 @@ class SacloudClient
             throw new Exception(sprintf("Error : WPError: [%s]", print_r($res, true)));
         } elseif (isset($res['is_fatal']) && $res['is_fatal'] === true) {
             throw new Exception(sprintf("AuthError: [%s]", print_r($res, true)));
-        } elseif (strpos($res['ExternalPermission'], 'cdn') === false) {
-            throw new Exception("AuthError : Is not have CDN permission ");
         }
         return true;
     }
@@ -1590,7 +1587,7 @@ class SacloudClient
 
     private function getAPIAuthURL()
     {
-        return sprintf(self::API_BASE_URL_FORAMT, $this->zone, self::API_CLOUD_SUFFIX) . "auth-status";
+        return sprintf(self::API_BASE_URL_FORAMT, $this->zone, self::API_WEBACCEL_SUFFIX) . "site";
     }
 
     private function getDeleteCacheURL()


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

APIキーを用いたテスト接続の対象を `GET /site`とする

実際にウェブアクセラレータのAPIを呼ぶため確実にチェックできるようになる
また、他のAPIへの依存が減り今後のメンテナンス性も向上するはず

### ドキュメントの変更は必要ですか？

no